### PR TITLE
Update admin interface as per images

### DIFF
--- a/q/x-main/xxx/templates/base.html
+++ b/q/x-main/xxx/templates/base.html
@@ -132,11 +132,6 @@
                             <i class="bi bi-box-arrow-in-right me-1"></i> Login
                         </a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link text-white fw-medium px-3 ms-2" href="{{ url_for('register') }}" style="border-radius: 6px; transition: all 0.2s ease; background: rgba(16, 185, 129, 0.1); border: 1px solid rgba(16, 185, 129, 0.3);">
-                            <i class="bi bi-person-plus me-1"></i> Register
-                        </a>
-                    </li>
                 {% endif %}
             </ul>
         </div>

--- a/q/x-main/xxx/templates/index.html
+++ b/q/x-main/xxx/templates/index.html
@@ -261,8 +261,8 @@
                         Start your free assessment today and get expert insights in minutes.
                     </p>
                     <div class="cta-actions">
-                        <a href="{{ url_for('register') }}" class="btn btn-cta-primary btn-lg me-3 mb-2">
-                            <i class="bi bi-rocket-takeoff me-2"></i>Start Free Assessment
+                        <a href="{{ url_for('login') }}" class="btn btn-cta-primary btn-lg me-3 mb-2">
+                            <i class="bi bi-box-arrow-in-right me-2"></i>Sign In to Start Assessment
                         </a>
                     </div>
 

--- a/q/x-main/xxx/templates/login.html
+++ b/q/x-main/xxx/templates/login.html
@@ -55,10 +55,7 @@
                                 <i class="bi bi-box-arrow-in-right me-2"></i>Sign In
                             </button>
 
-                            <div class="text-center">
-                                <span class="text-muted">Don't have an account? </span>
-                                <a href="{{ url_for('register') }}" class="link-primary">Sign up</a>
-                            </div>
+
                         </form>
                     </div>
                 </div>

--- a/q/x-main/xxx/templates/product_results.html
+++ b/q/x-main/xxx/templates/product_results.html
@@ -162,7 +162,7 @@
                                 
                                 <div class="dimension-labels mt-4">
                                     <h6 class="mb-3">Dimensions</h6>
-                                    {% for dimension, data in subdimension_scores.items() %}
+                                    {% for dimension, data in (subdimension_scores.items() | list | sort(attribute='1.average_score', reverse=true))[:5] %}
                                     <div class="dimension-label-item mb-2">
                                         <div class="dimension-color level-{{ data.average_score|round|int }}"></div>
                                         <span class="dimension-name">{{ dimension }}</span>
@@ -175,51 +175,7 @@
                     </div>
                 </div>
 
-                <!-- Ring-wise Maturity Heatmap -->
-                {% if ringwise_heatmap_data %}
-                <div class="ringwise-heatmap-container mb-4">
-                    <h6 class="text-muted mb-3">
-                        <i class="bi bi-target me-2"></i>Maturity Level Achievement Heatmap
-                    </h6>
-                    <div class="row">
-                        <div class="col-lg-8">
-                            <div id="ringwiseHeatmap" class="ringwise-heatmap"></div>
-                        </div>
-                        <div class="col-lg-4">
-                            <div class="maturity-legend">
-                                <h6 class="mb-3">Maturity Levels</h6>
-                                <div id="maturityLegend" class="maturity-legend-items">
-                                    <div class="legend-item">
-                                        <span class="legend-color achieved"></span>
-                                        <span>Achieved Level</span>
-                                    </div>
-                                    <div class="legend-item">
-                                        <span class="legend-color not-achieved"></span>
-                                        <span>Not Achieved</span>
-                                    </div>
-                                </div>
-                                <div class="current-level mt-3">
-                                    <h6>Current Level</h6>
-                                    <div class="badge bg-primary fs-6">
-                                        Level {{ ringwise_heatmap_data.achieved_level }} - 
-                                        {% if ringwise_heatmap_data.achieved_level == 5 %}
-                                            Optimized
-                                        {% elif ringwise_heatmap_data.achieved_level == 4 %}
-                                            Managed
-                                        {% elif ringwise_heatmap_data.achieved_level == 3 %}
-                                            Defined
-                                        {% elif ringwise_heatmap_data.achieved_level == 2 %}
-                                            Developing
-                                        {% else %}
-                                            Initial
-                                        {% endif %}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                {% endif %}
+
                 
                 {% endif %}
 
@@ -388,7 +344,7 @@
                                     {% endif %}
 
                                     <!-- Admin Review Actions -->
-                                    {% if is_admin_view %}
+                                    {% if session.role == 'lead' %}
                                         <div class="admin-review-section mt-3">
                                             {% set question_status = lead_comment.status if lead_comment else 'pending' %}
                                             {% if question_status in ['approved', 'rejected'] %}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement UI adjustments to remove registration, streamline result views, and restrict review actions to lead users.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses the user's request to remove the registration functionality, as admin users are responsible for creating client and lead accounts. It also simplifies the `product_results` page by removing the 'Maturity Level Achievement Heatmap' and limiting dimension scores to the top 5, as indicated in the provided images. Finally, it ensures that review actions (approve/reject/needs revision) are only visible to lead users, not administrators.

---
<a href="https://cursor.com/background-agent?bcId=bc-16e604e5-f85f-4df2-9553-72dff93e08ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16e604e5-f85f-4df2-9553-72dff93e08ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>