### PR TITLE
Implement client-lead communication interface

### DIFF
--- a/q/x-main/xxx/templates/dashboard_lead.html
+++ b/q/x-main/xxx/templates/dashboard_lead.html
@@ -253,7 +253,11 @@
                                                                 </td>
                                                                 <td>
                                                                     {% set lead_comment = resp.lead_comments|first %}
-                                                                    {% if lead_comment %}
+                                                                    {% if resp.is_approved %}
+                                                                        <span class="badge bg-success">
+                                                                            <i class="bi bi-check-circle me-1"></i>Approved
+                                                                        </span>
+                                                                    {% elif lead_comment %}
                                                                         {% if lead_comment.status == 'approved' %}
                                                                             <span class="badge bg-success">
                                                                                 <i class="bi bi-check-circle me-1"></i>Approved
@@ -275,14 +279,24 @@
                                                                 </td>
                                                                 <td>
                                                                     {% set lead_comment = resp.lead_comments|first %}
-                                                                    {% if lead_comment and lead_comment.status == 'approved' %}
+                                                                    {% if resp.is_approved or (lead_comment and lead_comment.status == 'approved') %}
                                                                         <button class="btn btn-success btn-sm" disabled>
                                                                             <i class="bi bi-check-circle-fill me-1"></i>Approved
                                                                         </button>
+                                                                        <a href="{{ url_for('unified_communication', product_id=resp.product_id) }}" 
+                                                                           class="btn btn-outline-secondary btn-sm ms-1"
+                                                                           title="View Communication History">
+                                                                            <i class="bi bi-chat-dots"></i>
+                                                                        </a>
                                                                     {% else %}
                                                                         <a href="{{ url_for('review_questionnaire', response_id=resp.id) }}"
                                                                            class="btn btn-outline-primary btn-sm">
                                                                             <i class="bi bi-pencil-square me-1"></i>Review
+                                                                        </a>
+                                                                        <a href="{{ url_for('unified_communication', product_id=resp.product_id) }}" 
+                                                                           class="btn btn-outline-info btn-sm ms-1"
+                                                                           title="Communication">
+                                                                            <i class="bi bi-chat-dots"></i>
                                                                         </a>
                                                                     {% endif %}
                                                                 </td>

--- a/q/x-main/xxx/templates/unified_communication.html
+++ b/q/x-main/xxx/templates/unified_communication.html
@@ -5,186 +5,110 @@
 {% block head %}
 <style>
 .communication-container {
-    max-width: 1200px;
+    max-width: 1400px;
     margin: 0 auto;
     padding: 20px;
+    height: calc(100vh - 140px);
+    display: flex;
+    flex-direction: column;
 }
 
 .conversation-header {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
-    padding: 25px;
-    border-radius: 12px;
-    margin-bottom: 25px;
+    padding: 20px 25px;
+    border-radius: 15px 15px 0 0;
+    margin-bottom: 0;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+    flex-shrink: 0;
+}
+
+.chat-container {
+    display: flex;
+    height: 100%;
+    background: white;
+    border-radius: 0 0 15px 15px;
+    overflow: hidden;
     box-shadow: 0 4px 20px rgba(0,0,0,0.1);
 }
 
+.conversation-sidebar {
+    width: 350px;
+    background: #f8f9fa;
+    border-right: 1px solid #e0e0e0;
+    overflow-y: auto;
+    flex-shrink: 0;
+}
+
+.dimension-section {
+    border-bottom: 1px solid #e0e0e0;
+}
+
 .dimension-header {
-    background: #f8f9fa;
-    border-left: 4px solid #667eea;
-    padding: 15px 20px;
-    margin: 20px 0 15px 0;
-    border-radius: 0 8px 8px 0;
-}
-
-.conversation-thread {
-    background: white;
-    border: 1px solid #e9ecef;
-    border-radius: 12px;
-    margin-bottom: 20px;
-    overflow: hidden;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
-}
-
-.thread-header {
-    background: #f8f9fa;
-    padding: 15px 20px;
-    border-bottom: 1px solid #e9ecef;
-}
-
-.thread-context {
-    font-size: 14px;
-    color: #6c757d;
-    margin-bottom: 5px;
-}
-
-.thread-title {
+    background: #667eea;
+    color: white;
+    padding: 12px 20px;
     font-weight: 600;
-    color: #2c3e50;
-}
-
-.message-item {
-    padding: 15px 20px;
-    border-bottom: 1px solid #f1f3f4;
-}
-
-.message-item:last-child {
-    border-bottom: none;
-}
-
-.message-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 10px;
-}
-
-.sender-info {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.sender-avatar {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 14px;
-    color: white;
-}
-
-.lead-avatar {
-    background: #667eea;
-}
-
-.client-avatar {
-    background: #28a745;
-}
-
-.message-content {
-    color: #2c3e50;
-    line-height: 1.6;
-    margin-bottom: 10px;
-}
-
-.message-meta {
-    font-size: 12px;
-    color: #868e96;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.status-badge {
-    padding: 4px 8px;
-    border-radius: 12px;
-    font-size: 11px;
-    font-weight: 500;
+    font-size: 0.9rem;
     text-transform: uppercase;
+    letter-spacing: 0.5px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
 }
 
-.status-pending { background: #fff3cd; color: #856404; }
-.status-approved { background: #d1edff; color: #0c5460; }
-.status-needs_revision { background: #f8d7da; color: #721c24; }
-.status-rejected { background: #f5c6cb; color: #721c24; }
-.status-client_reply { background: #d1ecf1; color: #0c5460; }
-.status-client_response { background: #d1ecf1; color: #0c5460; }
-
-.reply-section {
-    background: #f8f9fa;
+.conversation-list-item {
     padding: 15px 20px;
-    border-top: 1px solid #e9ecef;
-}
-
-.quick-reply {
-    display: flex;
-    gap: 10px;
-    align-items: flex-start;
-}
-
-.quick-reply textarea {
-    flex: 1;
-    border: 1px solid #ced4da;
-    border-radius: 8px;
-    padding: 10px;
-    resize: vertical;
-    min-height: 80px;
-}
-
-.reply-button {
-    background: #667eea;
-    color: white;
-    border: none;
-    padding: 10px 20px;
-    border-radius: 8px;
+    border-bottom: 1px solid #e8e8e8;
     cursor: pointer;
-    font-weight: 500;
-    transition: background 0.2s;
+    transition: all 0.2s ease;
+    position: relative;
 }
 
-.reply-button:hover {
-    background: #5a6fd8;
+.conversation-list-item:hover {
+    background: #e3f2fd;
 }
 
-.new-conversation-btn {
-    background: #28a745;
-    color: white;
-    border: none;
-    padding: 12px 24px;
-    border-radius: 8px;
-    font-weight: 500;
-    text-decoration: none;
-    display: inline-block;
-    transition: background 0.2s;
+.conversation-list-item.active {
+    background: #bbdefb;
+    border-left: 4px solid #667eea;
 }
 
-.new-conversation-btn:hover {
-    background: #218838;
-    color: white;
-    text-decoration: none;
+.conversation-preview {
+    margin-bottom: 8px;
 }
 
-.empty-state {
-    text-align: center;
-    padding: 60px 20px;
-    color: #6c757d;
+.conversation-title {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #2c3e50;
+    margin-bottom: 4px;
 }
 
-.unread-indicator {
-    background: #dc3545;
+.conversation-snippet {
+    font-size: 0.8rem;
+    color: #666;
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.conversation-meta {
+    display: flex;
+    justify-content: between;
+    align-items: center;
+    font-size: 0.75rem;
+    color: #999;
+}
+
+.conversation-time {
+    font-size: 0.75rem;
+    color: #999;
+}
+
+.unread-badge {
+    background: #667eea;
     color: white;
     border-radius: 50%;
     width: 20px;
@@ -192,35 +116,371 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 11px;
+    font-size: 0.7rem;
     font-weight: bold;
+    margin-left: auto;
 }
 
-.evidence-section {
+.chat-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.chat-header {
+    background: white;
+    padding: 15px 25px;
+    border-bottom: 1px solid #e0e0e0;
+    flex-shrink: 0;
+}
+
+.chat-thread-title {
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 4px;
+}
+
+.chat-thread-info {
+    font-size: 0.85rem;
+    color: #666;
+}
+
+.chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    background: #f0f2f5;
+    min-height: 0;
+}
+
+.message-group {
+    margin-bottom: 20px;
+}
+
+.message-bubble {
+    max-width: 70%;
+    margin-bottom: 8px;
+    position: relative;
+}
+
+.message-bubble.from-lead {
+    margin-left: auto;
+    text-align: right;
+}
+
+.message-bubble.from-client {
+    margin-right: auto;
+    text-align: left;
+}
+
+.message-content {
+    padding: 12px 16px;
+    border-radius: 18px;
+    word-wrap: break-word;
+    position: relative;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+.message-bubble.from-lead .message-content {
+    background: #667eea;
+    color: white;
+    border-bottom-right-radius: 4px;
+}
+
+.message-bubble.from-client .message-content {
+    background: white;
+    color: #2c3e50;
+    border-bottom-left-radius: 4px;
+    border: 1px solid #e0e0e0;
+}
+
+.message-sender {
+    font-size: 0.75rem;
+    margin-bottom: 4px;
+    font-weight: 600;
+}
+
+.message-bubble.from-lead .message-sender {
+    color: #667eea;
+}
+
+.message-bubble.from-client .message-sender {
+    color: #28a745;
+}
+
+.message-time {
+    font-size: 0.7rem;
+    opacity: 0.7;
+    margin-top: 4px;
+}
+
+.message-bubble.from-lead .message-time {
+    color: rgba(255,255,255,0.8);
+}
+
+.message-bubble.from-client .message-time {
+    color: #999;
+}
+
+.evidence-attachment {
+    background: rgba(255,255,255,0.1);
+    border-radius: 12px;
+    padding: 10px;
+    margin-top: 8px;
+    border: 1px solid rgba(255,255,255,0.2);
+}
+
+.message-bubble.from-client .evidence-attachment {
     background: #f8f9fa;
-    border-radius: 8px;
-    padding: 12px;
-    border-left: 3px solid #007bff;
-    margin-top: 10px;
+    border: 1px solid #e0e0e0;
 }
 
 .evidence-header {
     display: flex;
     align-items: center;
-    font-size: 0.9rem;
-    color: #495057;
-    margin-bottom: 8px;
+    font-size: 0.8rem;
+    margin-bottom: 6px;
+    color: rgba(255,255,255,0.9);
 }
 
-.evidence-content {
+.message-bubble.from-client .evidence-header {
+    color: #666;
+}
+
+.status-indicator {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.7rem;
+    font-weight: 500;
+    margin-left: 8px;
+}
+
+.status-needs-revision {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.status-approved {
+    background: #d4edda;
+    color: #155724;
+}
+
+.status-pending {
+    background: #d1ecf1;
+    color: #0c5460;
+}
+
+.status-rejected {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+.chat-input-area {
+    background: white;
+    padding: 20px 25px;
+    border-top: 1px solid #e0e0e0;
+    flex-shrink: 0;
+}
+
+.chat-input-form {
+    display: flex;
+    align-items: flex-end;
+    gap: 15px;
+}
+
+.chat-input-group {
+    flex: 1;
+}
+
+.chat-textarea {
+    width: 100%;
+    border: 1px solid #e0e0e0;
+    border-radius: 20px;
+    padding: 12px 16px;
+    resize: none;
+    outline: none;
+    font-family: inherit;
+    font-size: 0.9rem;
+    transition: border-color 0.2s ease;
+    max-height: 120px;
+    overflow-y: auto;
+}
+
+.chat-textarea:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.file-input-group {
+    margin-top: 8px;
+}
+
+.file-input-label {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.8rem;
+    color: #666;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 6px;
+    transition: background-color 0.2s;
+}
+
+.file-input-label:hover {
+    background: #f0f0f0;
+}
+
+.file-input {
+    display: none;
+}
+
+.send-button {
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 45px;
+    height: 45px;
     display: flex;
     align-items: center;
-    gap: 10px;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
 }
 
-.evidence-content .btn {
+.send-button:hover {
+    background: #5a6fd8;
+    transform: scale(1.05);
+}
+
+.send-button:disabled {
+    background: #ccc;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.approve-button {
+    background: #28a745;
+    color: white;
+    border: none;
+    border-radius: 12px;
+    padding: 8px 16px;
     font-size: 0.8rem;
-    padding: 6px 12px;
+    cursor: pointer;
+    margin-top: 8px;
+    transition: background-color 0.2s;
+}
+
+.approve-button:hover {
+    background: #218838;
+}
+
+.empty-chat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #999;
+    text-align: center;
+}
+
+.empty-chat i {
+    font-size: 4rem;
+    margin-bottom: 20px;
+    opacity: 0.5;
+}
+
+.question-context {
+    background: rgba(102, 126, 234, 0.1);
+    border-left: 4px solid #667eea;
+    padding: 12px 16px;
+    margin-bottom: 15px;
+    border-radius: 0 8px 8px 0;
+    font-size: 0.85rem;
+}
+
+.question-number {
+    font-weight: 600;
+    color: #667eea;
+    margin-bottom: 4px;
+}
+
+.question-text {
+    color: #2c3e50;
+    line-height: 1.4;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .communication-container {
+        padding: 10px;
+        height: calc(100vh - 120px);
+    }
+    
+    .conversation-header {
+        padding: 15px 20px;
+    }
+    
+    .conversation-sidebar {
+        width: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: 100;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        height: 100%;
+    }
+    
+    .conversation-sidebar.mobile-open {
+        transform: translateX(0);
+    }
+    
+    .chat-main {
+        width: 100%;
+    }
+    
+    .chat-input-form {
+        flex-direction: column;
+        gap: 10px;
+        align-items: stretch;
+    }
+    
+    .send-button {
+        width: 100%;
+        border-radius: 20px;
+        height: 40px;
+    }
+    
+    .message-bubble {
+        max-width: 85%;
+    }
+}
+
+/* Custom scrollbar */
+.conversation-sidebar::-webkit-scrollbar,
+.chat-messages::-webkit-scrollbar {
+    width: 6px;
+}
+
+.conversation-sidebar::-webkit-scrollbar-track,
+.chat-messages::-webkit-scrollbar-track {
+    background: #f1f1f1;
+}
+
+.conversation-sidebar::-webkit-scrollbar-thumb,
+.chat-messages::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 3px;
+}
+
+.conversation-sidebar::-webkit-scrollbar-thumb:hover,
+.chat-messages::-webkit-scrollbar-thumb:hover {
+    background: #a8a8a8;
 }
 </style>
 {% endblock %}
@@ -243,172 +503,227 @@
                     {% endif %}
                 </p>
             </div>
-            <div>
+            <div class="d-flex align-items-center">
                 {% if current_user_role == 'lead' %}
-                    <button class="new-conversation-btn" onclick="showNewConversationModal()">
+                    <button class="btn btn-light me-2" onclick="showNewConversationModal()">
                         <i class="bi bi-plus-lg me-2"></i>Start New Conversation
                     </button>
                 {% endif %}
+                <button class="btn btn-outline-light d-md-none" onclick="toggleSidebar()" id="sidebarToggle">
+                    <i class="bi bi-list"></i>
+                </button>
             </div>
         </div>
     </div>
 
-    <!-- Conversations organized by dimension -->
-    {% if conversations_by_dimension %}
-        {% for dimension, threads in conversations_by_dimension.items() %}
-            <!-- Dimension Header -->
-            <div class="dimension-header">
-                <h5 class="mb-0">
-                    <i class="bi bi-collection me-2"></i>{{ dimension }}
-                    <span class="badge bg-primary ms-2">{{ threads|length }} conversation{{ 's' if threads|length != 1 else '' }}</span>
-                </h5>
-            </div>
-
-            {% for thread in threads %}
-                <div class="conversation-thread">
-                    <!-- Thread Header -->
-                    <div class="thread-header">
-                        <div class="thread-context">
-                            {% if thread.root_comment.response %}
-                                {% set question_num = thread.root_comment.response.question | question_number %}
-                                Question #{{ question_num if question_num else 'N/A' }}: {{ thread.root_comment.response.question[:100] }}{% if thread.root_comment.response.question|length > 100 %}...{% endif %}
-                            {% else %}
-                                General Discussion
-                            {% endif %}
+    <!-- Chat Container -->
+    <div class="chat-container">
+        <!-- Conversation Sidebar -->
+        <div class="conversation-sidebar" id="conversationSidebar">
+            {% if conversations_by_dimension %}
+                {% for dimension, threads in conversations_by_dimension.items() %}
+                    <div class="dimension-section">
+                        <div class="dimension-header">
+                            <i class="bi bi-collection me-2"></i>{{ dimension }}
+                            <span class="badge bg-light text-dark ms-2">{{ threads|length }}</span>
                         </div>
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div class="thread-title">
-                                Conversation between {{ thread.root_comment.lead.username }} and {{ thread.root_comment.client.username }}
-                            </div>
-                            {% if thread.unread_count > 0 %}
-                                <div class="unread-indicator">{{ thread.unread_count }}</div>
-                            {% endif %}
-                        </div>
-                    </div>
-
-                    <!-- Root Message -->
-                    <div class="message-item">
-                        <div class="message-header">
-                            <div class="sender-info">
-                                <div class="sender-avatar lead-avatar">
-                                    <i class="bi bi-person-badge"></i>
+                        {% for thread in threads %}
+                            <div class="conversation-list-item {% if loop.parent.loop.first and loop.first %}active{% endif %}" 
+                                 onclick="selectConversation('{{ dimension|replace(' ', '_') }}_{{ loop.index }}')"
+                                 data-conversation-id="{{ dimension|replace(' ', '_') }}_{{ loop.index }}">
+                                <div class="conversation-preview">
+                                    <div class="conversation-title">
+                                        {% if thread.root_comment.response %}
+                                            {% set question_num = thread.root_comment.response.question | question_number %}
+                                            Question #{{ question_num if question_num else 'N/A' }}
+                                        {% else %}
+                                            General Discussion
+                                        {% endif %}
+                                    </div>
+                                    <div class="conversation-snippet">
+                                        {{ thread.root_comment.comment[:60] }}{% if thread.root_comment.comment|length > 60 %}...{% endif %}
+                                    </div>
                                 </div>
-                                <div>
-                                    <strong>{{ thread.root_comment.lead.username }}</strong>
-                                    <small class="text-muted">(Lead Reviewer)</small>
-                                </div>
-                            </div>
-                            <div class="message-meta">
-                                <span>{{ thread.root_comment.created_at.strftime('%m/%d/%Y %I:%M %p') }}</span>
-                                <span class="status-badge status-{{ thread.root_comment.status }}">
-                                    {{ thread.root_comment.status.replace('_', ' ').title() }}
-                                </span>
-                            </div>
-                        </div>
-                        <div class="message-content">
-                            {{ thread.root_comment.comment }}
-                        </div>
-                    </div>
-
-                    <!-- Replies -->
-                    {% for reply in thread.replies %}
-                        <div class="message-item">
-                            <div class="message-header">
-                                <div class="sender-info">
-                                    {% if reply.status in ['client_reply', 'client_response'] %}
-                                        <div class="sender-avatar client-avatar">
-                                            <i class="bi bi-person-circle"></i>
-                                        </div>
-                                        <div>
-                                            <strong>{{ reply.client.username }}</strong>
-                                            <small class="text-muted">(Client)</small>
-                                        </div>
-                                    {% else %}
-                                        <div class="sender-avatar lead-avatar">
-                                            <i class="bi bi-person-badge"></i>
-                                        </div>
-                                        <div>
-                                            <strong>{{ reply.lead.username }}</strong>
-                                            <small class="text-muted">(Lead Reviewer)</small>
-                                        </div>
-                                    {% endif %}
-                                </div>
-                                <div class="message-meta">
-                                    <span>{{ reply.created_at.strftime('%m/%d/%Y %I:%M %p') }}</span>
-                                    {% if not reply.is_read %}
-                                        <span class="badge bg-primary">New</span>
+                                <div class="conversation-meta">
+                                    <span class="conversation-time" title="Last activity: {{ thread.last_activity.strftime('%B %d, %Y at %I:%M %p') }}">
+                                        {{ thread.last_activity.strftime('%m/%d %I:%M %p') }}
+                                    </span>
+                                    {% if thread.unread_count > 0 %}
+                                        <div class="unread-badge" title="{{ thread.unread_count }} unread message{{ 's' if thread.unread_count != 1 else '' }}">{{ thread.unread_count }}</div>
                                     {% endif %}
                                 </div>
                             </div>
-                            <div class="message-content">
-                                {{ reply.comment }}
-                            </div>
-                            
-                            <!-- Show evidence if available for client replies -->
-                            {% if reply.status in ['client_reply', 'client_response'] and reply.response and reply.response.evidence_path %}
-                            <div class="evidence-section">
-                                <div class="evidence-header">
-                                    <i class="bi bi-paperclip text-primary me-2"></i>
-                                    <strong class="text-primary">Evidence Attached</strong>
-                                </div>
-                                <div class="evidence-content">
-                                    <a href="{{ url_for('uploaded_file', filename=reply.response.evidence_path.split('/')[-1]) }}" 
-                                       target="_blank" 
-                                       class="btn btn-outline-primary btn-sm">
-                                        <i class="bi bi-download me-1"></i>View Evidence
-                                    </a>
-                                    <small class="text-muted ms-2">
-                                        Updated: {{ reply.created_at.strftime('%m/%d/%Y %I:%M %p') }}
-                                    </small>
-                                </div>
-                            </div>
-                            {% endif %}
-                        </div>
-                    {% endfor %}
-
-                    <!-- Reply Section -->
-                    <div class="reply-section">
-                        <form method="post" action="{{ url_for('reply_to_conversation', comment_id=thread.root_comment.id) }}" enctype="multipart/form-data">
-                            <div class="quick-reply">
-                                <div style="flex: 1;">
-                                    <textarea name="reply" placeholder="Type your reply..." required></textarea>
-                                    {% if current_user_role == 'client' and thread.root_comment.status in ['needs_revision', 'rejected'] %}
-                                        <div class="mt-2">
-                                            <label class="form-label">
-                                                <i class="bi bi-paperclip me-1"></i>Attach Evidence (Optional)
-                                            </label>
-                                            <input type="file" class="form-control form-control-sm" name="evidence"
-                                                   accept=".csv,.txt,.pdf,.jpg,.jpeg,.png,.doc,.docx">
-                                        </div>
-                                    {% endif %}
-                                </div>
-                                <button type="submit" class="reply-button">
-                                    <i class="bi bi-send me-1"></i>Send
-                                </button>
-                            </div>
-                        </form>
+                        {% endfor %}
                     </div>
+                {% endfor %}
+            {% else %}
+                <div class="empty-chat">
+                    <i class="bi bi-chat-text"></i>
+                    <p>No conversations yet</p>
                 </div>
-            {% endfor %}
-        {% endfor %}
-    {% else %}
-        <div class="empty-state">
-            <i class="bi bi-chat-text display-4 mb-3"></i>
-            <h4>No conversations yet</h4>
-            <p class="mb-3">
-                {% if current_user_role == 'lead' %}
-                    Start a new conversation with your clients to provide feedback and guidance.
-                {% else %}
-                    Your security reviewer will start conversations here to provide feedback.
-                {% endif %}
-            </p>
-            {% if current_user_role == 'lead' %}
-                <button class="new-conversation-btn" onclick="showNewConversationModal()">
-                    <i class="bi bi-plus-lg me-2"></i>Start First Conversation
-                </button>
             {% endif %}
         </div>
-    {% endif %}
+
+        <!-- Chat Main Area -->
+        <div class="chat-main">
+            {% if conversations_by_dimension %}
+                {% for dimension, threads in conversations_by_dimension.items() %}
+                    {% for thread in threads %}
+                        <div class="chat-conversation {% if loop.parent.loop.first and loop.first %}active{% endif %}" 
+                             id="conversation_{{ dimension|replace(' ', '_') }}_{{ loop.index }}"
+                             style="{% if not (loop.parent.loop.first and loop.first) %}display: none;{% endif %}">
+                            
+                            <!-- Chat Header -->
+                            <div class="chat-header">
+                                <div class="chat-thread-title">
+                                    Conversation with {{ thread.root_comment.client.username }}
+                                    {% if thread.root_comment.status != 'approved' %}
+                                        <span class="status-indicator status-{{ thread.root_comment.status.replace('_', '-') }}" 
+                                              title="Status: {{ thread.root_comment.status.replace('_', ' ').title() }}">
+                                            {{ thread.root_comment.status.replace('_', ' ').title() }}
+                                        </span>
+                                    {% endif %}
+                                </div>
+                                <div class="chat-thread-info">
+                                    {% if thread.root_comment.response %}
+                                        {% set question_num = thread.root_comment.response.question | question_number %}
+                                        Question #{{ question_num if question_num else 'N/A' }} • {{ dimension }}
+                                    {% else %}
+                                        General Discussion • {{ dimension }}
+                                    {% endif %}
+                                </div>
+                            </div>
+
+                            <!-- Chat Messages -->
+                            <div class="chat-messages">
+                                <!-- Question Context (if available) -->
+                                {% if thread.root_comment.response %}
+                                    <div class="question-context">
+                                        <div class="question-number">
+                                            Question #{{ thread.root_comment.response.question | question_number if thread.root_comment.response.question | question_number else 'N/A' }}
+                                        </div>
+                                        <div class="question-text">
+                                            {{ thread.root_comment.response.question }}
+                                        </div>
+                                    </div>
+                                {% endif %}
+
+                                <!-- Root Message -->
+                                <div class="message-group">
+                                    <div class="message-bubble from-lead">
+                                        <div class="message-sender">
+                                            {{ thread.root_comment.lead.username }} (Lead Reviewer)
+                                        </div>
+                                        <div class="message-content">
+                                            {{ thread.root_comment.comment }}
+                                            <div class="message-time">
+                                                {{ thread.root_comment.created_at.strftime('%m/%d/%Y %I:%M %p') }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Replies -->
+                                {% for reply in thread.replies %}
+                                    <div class="message-group">
+                                        <div class="message-bubble {% if reply.status in ['client_reply', 'client_response'] %}from-client{% else %}from-lead{% endif %}">
+                                            <div class="message-sender">
+                                                {% if reply.status in ['client_reply', 'client_response'] %}
+                                                    {{ reply.client.username }} (Client)
+                                                {% else %}
+                                                    {{ reply.lead.username }} (Lead Reviewer)
+                                                {% endif %}
+                                                {% if not reply.is_read %}
+                                                    <span class="badge bg-primary ms-1">New</span>
+                                                {% endif %}
+                                            </div>
+                                            <div class="message-content">
+                                                {{ reply.comment }}
+                                                
+                                                <!-- Evidence Attachment -->
+                                                {% if reply.status in ['client_reply', 'client_response'] and reply.response and reply.response.evidence_path %}
+                                                    <div class="evidence-attachment">
+                                                        <div class="evidence-header">
+                                                            <i class="bi bi-paperclip me-2"></i>
+                                                            Evidence Attached
+                                                        </div>
+                                                        <a href="{{ url_for('uploaded_file', filename=reply.response.evidence_path.split('/')[-1]) }}" 
+                                                           target="_blank" 
+                                                           class="btn btn-sm btn-outline-light">
+                                                            <i class="bi bi-download me-1"></i>View Evidence
+                                                        </a>
+                                                    </div>
+                                                {% endif %}
+                                                
+                                                <div class="message-time">
+                                                    {{ reply.created_at.strftime('%m/%d/%Y %I:%M %p') }}
+                                                </div>
+
+                                                <!-- Approve Button for Lead -->
+                                                {% if current_user_role == 'lead' and reply.status in ['client_reply', 'client_response'] and reply.status != 'approved' %}
+                                                    <form method="post" action="{{ url_for('approve_client_reply', comment_id=reply.id) }}" style="display: inline;" onsubmit="return confirmApproval()">
+                                                        <button type="submit" class="approve-button">
+                                                            <i class="bi bi-check-circle me-1"></i>Approve Response
+                                                        </button>
+                                                    </form>
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+
+                            <!-- Chat Input Area -->
+                            <div class="chat-input-area">
+                                <form method="post" action="{{ url_for('reply_to_conversation', comment_id=thread.root_comment.id) }}" 
+                                      enctype="multipart/form-data" class="chat-input-form">
+                                    <div class="chat-input-group">
+                                        <textarea name="reply" class="chat-textarea" 
+                                                  placeholder="Type your message..." 
+                                                  required 
+                                                  rows="1"
+                                                  onInput="autoResize(this)"></textarea>
+                                        
+                                        {% if current_user_role == 'client' and thread.root_comment.status in ['needs_revision', 'rejected'] %}
+                                            <div class="file-input-group">
+                                                <label for="evidence_{{ dimension|replace(' ', '_') }}_{{ loop.index }}" class="file-input-label">
+                                                    <i class="bi bi-paperclip me-1"></i>Attach Evidence (Optional)
+                                                </label>
+                                                <input type="file" class="file-input" 
+                                                       id="evidence_{{ dimension|replace(' ', '_') }}_{{ loop.index }}"
+                                                       name="evidence"
+                                                       accept=".csv,.txt,.pdf,.jpg,.jpeg,.png,.doc,.docx">
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                    <button type="submit" class="send-button">
+                                        <i class="bi bi-send"></i>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    {% endfor %}
+                {% endfor %}
+            {% else %}
+                <div class="empty-chat">
+                    <i class="bi bi-chat-text"></i>
+                    <h4>No conversations yet</h4>
+                    <p>
+                        {% if current_user_role == 'lead' %}
+                            Start a new conversation with your clients to provide feedback and guidance.
+                        {% else %}
+                            Your security reviewer will start conversations here to provide feedback.
+                        {% endif %}
+                    </p>
+                    {% if current_user_role == 'lead' %}
+                        <button class="btn btn-primary" onclick="showNewConversationModal()">
+                            <i class="bi bi-plus-lg me-2"></i>Start First Conversation
+                        </button>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
 </div>
 
 <!-- New Conversation Modal (for leads) -->
@@ -467,20 +782,155 @@
 {% endif %}
 
 <script>
+let currentConversationId = null;
+
+function selectConversation(conversationId) {
+    // Remove active class from all conversation items
+    document.querySelectorAll('.conversation-list-item').forEach(item => {
+        item.classList.remove('active');
+    });
+    
+    // Hide all conversation views
+    document.querySelectorAll('.chat-conversation').forEach(conv => {
+        conv.style.display = 'none';
+    });
+    
+    // Show selected conversation
+    const selectedItem = document.querySelector(`[data-conversation-id="${conversationId}"]`);
+    const selectedConversation = document.getElementById(`conversation_${conversationId}`);
+    
+    if (selectedItem && selectedConversation) {
+        selectedItem.classList.add('active');
+        selectedConversation.style.display = 'flex';
+        selectedConversation.style.flexDirection = 'column';
+        selectedConversation.style.height = '100%';
+        currentConversationId = conversationId;
+        
+        // Scroll to bottom of messages
+        const messagesContainer = selectedConversation.querySelector('.chat-messages');
+        if (messagesContainer) {
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        }
+        
+        // Close sidebar on mobile after selection
+        if (window.innerWidth <= 768) {
+            toggleSidebar();
+        }
+    }
+}
+
+function toggleSidebar() {
+    const sidebar = document.getElementById('conversationSidebar');
+    sidebar.classList.toggle('mobile-open');
+    
+    const toggleButton = document.getElementById('sidebarToggle');
+    const icon = toggleButton.querySelector('i');
+    
+    if (sidebar.classList.contains('mobile-open')) {
+        icon.className = 'bi bi-x';
+    } else {
+        icon.className = 'bi bi-list';
+    }
+}
+
 function showNewConversationModal() {
     const modal = new bootstrap.Modal(document.getElementById('newConversationModal'));
     modal.show();
 }
 
-// Auto-scroll to bottom of conversations
+function autoResize(textarea) {
+    textarea.style.height = 'auto';
+    textarea.style.height = Math.min(textarea.scrollHeight, 120) + 'px';
+}
+
+// Initialize first conversation as active on page load
 document.addEventListener('DOMContentLoaded', function() {
-    const conversationThreads = document.querySelectorAll('.conversation-thread');
-    conversationThreads.forEach(thread => {
-        const replySection = thread.querySelector('.reply-section');
-        if (replySection) {
-            replySection.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    const firstConversationItem = document.querySelector('.conversation-list-item');
+    if (firstConversationItem) {
+        const conversationId = firstConversationItem.getAttribute('data-conversation-id');
+        if (conversationId) {
+            selectConversation(conversationId);
         }
+    }
+    
+    // Auto-scroll to bottom of all message containers
+    document.querySelectorAll('.chat-messages').forEach(container => {
+        container.scrollTop = container.scrollHeight;
     });
 });
+
+// Handle file input visual feedback
+document.addEventListener('change', function(e) {
+    if (e.target.classList.contains('file-input')) {
+        const label = e.target.previousElementSibling;
+        if (e.target.files.length > 0) {
+            label.innerHTML = `<i class="bi bi-paperclip me-1"></i>${e.target.files[0].name}`;
+            label.style.color = '#667eea';
+        } else {
+            label.innerHTML = `<i class="bi bi-paperclip me-1"></i>Attach Evidence (Optional)`;
+            label.style.color = '#666';
+        }
+    }
+});
+
+// Add Enter key support for sending messages
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && !e.shiftKey && e.target.classList.contains('chat-textarea')) {
+        e.preventDefault();
+        const form = e.target.closest('form');
+        if (form && e.target.value.trim()) {
+            form.submit();
+        }
+    }
+});
+
+// Confirmation for approval
+function confirmApproval() {
+    return confirm('Are you sure you want to approve this response? This will mark the conversation as resolved and move it to approved responses.');
+}
+
+// Auto-refresh for new messages (every 30 seconds)
+setInterval(function() {
+    // Only refresh if user is not actively typing
+    const activeTextarea = document.querySelector('.chat-textarea:focus');
+    if (!activeTextarea || !activeTextarea.value.trim()) {
+        // Check for new messages without full page reload
+        checkForNewMessages();
+    }
+}, 30000);
+
+function checkForNewMessages() {
+    // Simple implementation - could be enhanced with WebSocket or SSE
+    const currentUrl = window.location.href;
+    if (currentUrl.includes('/communication/')) {
+        // Only refresh if no modal is open and user isn't typing
+        const openModal = document.querySelector('.modal.show');
+        const focusedTextarea = document.querySelector('.chat-textarea:focus');
+        
+        if (!openModal && !focusedTextarea) {
+            // Silent refresh of conversation data
+            fetch(currentUrl, {
+                method: 'GET',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            }).then(response => {
+                if (response.ok) {
+                    // Could implement partial updates here
+                    // For now, we'll just update unread indicators
+                    updateUnreadIndicators();
+                }
+            }).catch(error => {
+                // Silently handle errors
+                console.log('Auto-refresh failed:', error);
+            });
+        }
+    }
+}
+
+function updateUnreadIndicators() {
+    // Update unread count badges without full page reload
+    // Implementation would depend on API endpoint for unread counts
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement a WhatsApp-like communication interface to streamline lead-client interactions and automate the approval workflow for questionnaire responses.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR transforms the existing communication feature into a user-friendly, dimension-wise organized chat interface. It ensures that client replies with evidence are neatly presented to the lead and, upon approval, are automatically marked as resolved, removed from active communication, and reflected in the "Questionnaire Responses" section, as per the user's request for a "proper neat communication interface[like whtsapp]".

---
<a href="https://cursor.com/background-agent?bcId=bc-73ebf7c6-e82e-4fa5-81d1-99e0217d4d46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73ebf7c6-e82e-4fa5-81d1-99e0217d4d46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>